### PR TITLE
Support Python 3.5, 3.6, 3.7 on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A Python client library for the Dynata Demand API"
 authors = ["Ridley Larsen <Ridley.Larsen@dynata.com>", "Bradley Wogsland <Bradley.Wogsland@dynata.com>", "Nathan Workman <Nathan.Workman@dynata.com>"]
 
 [tool.poetry.dependencies]
-python = "^2.7"
+python = "^2.7 || ^3.5 || ^3.6 || ^3.7"
 responses = "0.10.6"
 requests = "2.22.0"
 pytest = "4.6.6"


### PR DESCRIPTION
* Added supported versions to pyproject.toml

Resolves #36.